### PR TITLE
Skip checking and uploading assets that exist

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,11 +37,11 @@ jobs:
           pushd ./../.github/actions/
             git clone https://github.com/actions/setup-python.git
             pushd setup-python/
-              git checkout 28a6c1b915d5808acb3da49af7063544ebfbe085
+              git checkout v2
             popd
             git clone https://github.com/actions/checkout.git
             pushd checkout/
-              git checkout 722adc63f1aa60a57ec37892e133b1d319cae598
+              git checkout v2
             popd
           popd
         shell: bash

--- a/github_release_retry/github_release_retry.py
+++ b/github_release_retry/github_release_retry.py
@@ -292,6 +292,20 @@ def upload_file(
     retry_count = 0
     wait_time = 2
 
+    # Optimization:
+    # We don't trust the |release| object; assets that exist on the releases web page might be missing from this object.
+    # However, if the asset *does* exist in the |release| object, and has the correct size and state, then we can assume
+    # it has already been uploaded without making any further remote API calls.
+    if release.assets:
+        for asset in release.assets:
+            if (
+                asset.name == file_path.name
+                and asset.size == file_size
+                and asset.state == "uploaded"
+            ):
+                log("The asset has the correct size and state. Asset done.\n")
+                return
+
     # Only exit the loop if we manage to verify that the asset has the expected size and state, or if we hit the retry limit.
     while True:
 

--- a/github_release_retry/github_release_retry.py
+++ b/github_release_retry/github_release_retry.py
@@ -281,7 +281,7 @@ class HitRetryLimitError(Exception):
     pass
 
 
-def upload_file(
+def upload_file(  # pylint: disable=too-many-branches;
     g: GithubApi, release: Release, file_path: Path  # noqa: VNE001
 ) -> None:
 


### PR DESCRIPTION
As an optimization, skip checking and uploading assets that already exist in the Release object. Apart from this, we do not trust the Release object.

Fixes #4.